### PR TITLE
Use 'value' property to comply with v-model

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,16 @@ Use the component in your `template`. Make sure to change `variable` to a string
 the editor should start with (it can be an empty string too).
 
 ```
-<editor :content="variable"></editor>
+<editor :value="variable"></editor>
 ```
 
+Alternatively, create a two-way binding between editor content and component data using v-model:
 
-The content-prop is required, the other props have the following defaults:
+```
+<editor v-model="myVariable"></editor>
+```
+
+The value prop is required, the other props have the following defaults:
 
 ```
 lang: javascript
@@ -84,12 +89,9 @@ data () {
 }
 ```
 
-Last but not least listen on the `editor-update`. Make sure to replace
-`vm.function` with the function you want to execute.
+Last but not least: listen to the `input` event. `onEditorContentUpdate`
+is the function you'd like to call on update.
 
 ```
-mounted () {
-  var vm = this;
-  vm.$on('editor-update', vm.function);
-}
+<editor @input="onEditorContentUpdate"></editor>
 ```

--- a/index.js
+++ b/index.js
@@ -58,11 +58,9 @@ module.exports = {
   },
 
   watch: {
-    content: function (newContent) {
+    value: function (newContent) {
       var vm = this;
-      if (vm.sync) {
-        vm.editor.setValue(newContent, 1);
-      }
+      vm.editor.setValue(newContent, 1);
     },
 
     theme: function (newTheme) {

--- a/index.js
+++ b/index.js
@@ -2,9 +2,11 @@ var ace = require('brace');
 
 module.exports = {
   template: '<div :style="{height: height, width: width}"></div>',
-
+  model: {
+    prop: 'content'
+  },
   props: {
-    value: {
+    content: {
       type: String,
       required: true
     },
@@ -24,12 +26,8 @@ module.exports = {
       type: String,
       default: '100%'
     },
-    sync: {
-      type: Boolean,
-      default: false
-    },
-    options: {
-      type: Object,
+    options: {		
+      type: Object,		
       default: function () { return {}; }
     }
   },
@@ -37,6 +35,7 @@ module.exports = {
   data: function () {
     return {
       editor: null,
+      lastContent: ""
     };
   },
 
@@ -49,21 +48,25 @@ module.exports = {
     editor.$blockScrolling = Infinity;
     editor.getSession().setMode('ace/mode/' + lang);
     editor.setTheme('ace/theme/' + theme);
-    editor.setValue(vm.value, 1);
+    editor.setValue(vm.content, 1);
     editor.setOptions(options);
 
     editor.on('change', function () {
       vm.$emit('input', editor.getValue());
+      vm.$parent.$emit('editor-update', editor.getValue());
+      vm.lastContent = vm.content;
     });
   },
 
   watch: {
-    value: function (newContent) {
+    content(newContent) {
       var vm = this;
-      vm.editor.setValue(newContent, 1);
+      if (vm.lastContent != newContent){
+        vm.editor.setValue(newContent, 1);
+      }
     },
 
-    theme: function (newTheme) {
+    theme(newTheme) {
       var vm = this;
       vm.editor.setTheme('ace/theme/' + newTheme);
     }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = {
   template: '<div :style="{height: height, width: width}"></div>',
 
   props: {
-    content: {
+    value: {
       type: String,
       required: true
     },
@@ -49,10 +49,11 @@ module.exports = {
     editor.$blockScrolling = Infinity;
     editor.getSession().setMode('ace/mode/' + lang);
     editor.setTheme('ace/theme/' + theme);
-    editor.setValue(vm.content, 1);
+    editor.setValue(vm.value, 1);
     editor.setOptions(options);
+
     editor.on('change', function () {
-      vm.$parent.$emit('editor-update', editor.getValue());
+      vm.$emit('input', editor.getValue());
     });
   },
 


### PR DESCRIPTION
For more info: https://vuejs.org/v2/guide/components.html#Form-Input-Components-using-Custom-Events

> So for a component to work with v-model, it should (these can be configured in 2.2.0+):
> - accept a value prop
> - emit an input event with the new value

This allows creating a two-way binding of the editor content to a component's data. 

```
<editor v-model="myEditorContent" ... />
```

It is still possible to specify only a 1-way binding with `:value` or listen for edits with `@input`.

I think using `v-model` might also be more elegant than using the "sync" option and a Watcher, but that could be a matter of taste. 😄 